### PR TITLE
Chats

### DIFF
--- a/app/api/chats.py
+++ b/app/api/chats.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, HTTPException
+from uuid import uuid4
+
+from app.utils.db import db_instance
+from app.setup_rollbar import rollbar_handler
+from app.models.chat import CreateChat
+
+router = APIRouter()
+
+@router.post("/create_chat")
+@rollbar_handler
+async def create_chat(payload: CreateChat):
+    if payload.isu_1 == payload.isu_2:
+        raise HTTPException(status_code=400, detail="Chat cannot be created for the same user")
+
+    chat_id = str(uuid4())
+    await db_instance.create_chat(chat_id=chat_id, isu_1=payload.isu_1, isu_2=payload.isu_2)
+    return {"message": "Chat created", "chat_id": chat_id}
+
+@router.get("/user_chats/{isu}")
+@rollbar_handler
+async def get_chats_for_user(isu: int):
+    chats = await db_instance.get_chats_by_user(isu)
+    if not chats:
+        raise HTTPException(status_code=404, detail="chats not found for this user")
+    
+    return {"chats": chats}

--- a/app/api/chats.py
+++ b/app/api/chats.py
@@ -11,7 +11,7 @@ router = APIRouter()
 @rollbar_handler
 async def create_chat(payload: CreateChat):
     if payload.isu_1 == payload.isu_2:
-        raise HTTPException(status_code=400, detail="Chat cannot be created for the same user")
+        raise HTTPException(status_code=400, detail="chat cannot be created for the same user")
 
     chat_id = str(uuid4())
     await db_instance.create_chat(chat_id=chat_id, isu_1=payload.isu_1, isu_2=payload.isu_2)

--- a/app/api/chats.py
+++ b/app/api/chats.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from app.utils.db import db_instance
 from app.setup_rollbar import rollbar_handler
-from app.models.chat import CreateChat, SendMessage, MessagesResponse
+from app.models.chat import CreateChat, SendMessage
 
 router = APIRouter()
 
@@ -37,7 +37,7 @@ async def send_message(payload: SendMessage):
     )
     return {"message": "message sent", "message_id": message_id}
 
-@router.get("/get_messages/{chat_id}", response_model=MessagesResponse)
+@router.get("/get_messages/{chat_id}")
 @rollbar_handler
 async def get_messages(chat_id: str, limit: int = Query(5, gt=0), offset: int = Query(0, ge=0)):
     messages = await db_instance.get_messages(chat_id=chat_id, limit=limit, offset=offset)

--- a/app/api/chats.py
+++ b/app/api/chats.py
@@ -26,7 +26,7 @@ async def get_chats_for_user(isu: int):
     
     return {"chats": chats}
 
-@router.post("/send_message", response_model=dict)
+@router.post("/send_message")
 @rollbar_handler
 async def send_message(payload: SendMessage):
     message_id = await db_instance.create_message(

--- a/app/api/chats.py
+++ b/app/api/chats.py
@@ -15,7 +15,7 @@ async def create_chat(payload: CreateChat):
 
     chat_id = str(uuid4())
     await db_instance.create_chat(chat_id=chat_id, isu_1=payload.isu_1, isu_2=payload.isu_2)
-    return {"message": "Chat created", "chat_id": chat_id}
+    return {"chat_id": chat_id}
 
 @router.get("/user_chats/{isu}")
 @rollbar_handler
@@ -35,7 +35,7 @@ async def send_message(payload: SendMessage):
         receiver_id=payload.receiver_id,
         text=payload.text
     )
-    return {"message": "message sent", "message_id": message_id}
+    return {"message_id": message_id}
 
 @router.get("/get_messages/{chat_id}")
 @rollbar_handler

--- a/app/api/chats.py
+++ b/app/api/chats.py
@@ -1,9 +1,9 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from uuid import uuid4
 
 from app.utils.db import db_instance
 from app.setup_rollbar import rollbar_handler
-from app.models.chat import CreateChat
+from app.models.chat import CreateChat, SendMessage, MessagesResponse
 
 router = APIRouter()
 
@@ -25,3 +25,22 @@ async def get_chats_for_user(isu: int):
         raise HTTPException(status_code=404, detail="chats not found for this user")
     
     return {"chats": chats}
+
+@router.post("/send_message", response_model=dict)
+@rollbar_handler
+async def send_message(payload: SendMessage):
+    message_id = await db_instance.create_message(
+        chat_id=payload.chat_id,
+        sender_id=payload.sender_id,
+        receiver_id=payload.receiver_id,
+        text=payload.text
+    )
+    return {"message": "message sent", "message_id": message_id}
+
+@router.get("/get_messages/{chat_id}", response_model=MessagesResponse)
+@rollbar_handler
+async def get_messages(chat_id: str, limit: int = Query(5, gt=0), offset: int = Query(0, ge=0)):
+    messages = await db_instance.get_messages(chat_id=chat_id, limit=limit, offset=offset)
+    if not messages:
+        raise HTTPException(status_code=404, detail="messages not found")
+    return {"messages": messages}

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from app.api import quizes_results
 from app.api import auth
 from app.api import register
 from app.api import profile
+from app.api import chats
 from app import setup_rollbar
 
 app = FastAPI()
@@ -15,6 +16,7 @@ app.include_router(quizes_results.router, prefix="/results")
 app.include_router(auth.router, prefix="/auth")
 app.include_router(register.router, prefix="/auth")
 app.include_router(profile.router, prefix="/profile")
+app.include_router(chats.router, prefix="/chats")
 
 
 def main():

--- a/app/models/chat.py
+++ b/app/models/chat.py
@@ -1,6 +1,23 @@
 from pydantic import BaseModel
-
+import datetime
+from typing import List
 
 class CreateChat(BaseModel):
     isu_1: int
     isu_2: int
+
+class SendMessage(BaseModel):
+    chat_id: str
+    sender_id: int
+    receiver_id: int
+    text: str
+
+class Message(BaseModel):
+    message_id: str
+    sender_id: int
+    receiver_id: int
+    text: str
+    timestamp: datetime.datetime
+
+class MessagesResponse(BaseModel):
+    messages: List[Message]

--- a/app/models/chat.py
+++ b/app/models/chat.py
@@ -1,6 +1,5 @@
 from pydantic import BaseModel
 import datetime
-from typing import List
 
 class CreateChat(BaseModel):
     isu_1: int
@@ -18,6 +17,3 @@ class Message(BaseModel):
     receiver_id: int
     text: str
     timestamp: datetime.datetime
-
-class MessagesResponse(BaseModel):
-    messages: List[Message]

--- a/app/models/chat.py
+++ b/app/models/chat.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class CreateChat(BaseModel):
+    isu_1: int
+    isu_2: int

--- a/app/models/chat.py
+++ b/app/models/chat.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel
-import datetime
 
 class CreateChat(BaseModel):
     isu_1: int
@@ -10,10 +9,3 @@ class SendMessage(BaseModel):
     sender_id: int
     receiver_id: int
     text: str
-
-class Message(BaseModel):
-    message_id: str
-    sender_id: int
-    receiver_id: int
-    text: str
-    timestamp: datetime.datetime

--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -1,9 +1,10 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from motor.motor_asyncio import AsyncIOMotorClient
 import os
 from dotenv import load_dotenv
 from minio import Minio
 from bson import ObjectId
+import datetime
 
 from app.setup_rollbar import rollbar_handler
 
@@ -156,6 +157,27 @@ class Database:
         return result
 
         return [str(tag_id) for tag_id in result.inserted_ids]
+    
+    @rollbar_handler
+    async def create_chat(self, chat_id: str, isu_1: int, isu_2: int, status: Optional[str] = "active"):
+        chat_data = {
+            "chat_id": chat_id,
+            "isu_1": isu_1,
+            "isu_2": isu_2,
+            "created_at": datetime.datetime.now(datetime.timezone.utc),
+            "status": status
+        }
+        result = await self.db["chats"].insert_one(chat_data)
+        return str(result)
+    
+    @rollbar_handler
+    async def get_chats_by_user(self, isu: int):
+        result = await self.db["chats"].find(
+            {"$or": [{"isu_1": isu}, {"isu_2": isu}]}
+        ).to_list(length=None)
+        return [{"chat_id": chat["chat_id"]} for chat in result]
+
+
 
 
 db_instance = Database()

--- a/tests/unit/chats_test.py
+++ b/tests/unit/chats_test.py
@@ -1,0 +1,125 @@
+import pytest
+from fastapi import HTTPException
+from unittest.mock import AsyncMock, MagicMock, patch
+from app.api.chats import (
+    create_chat,
+    get_chats_for_user,
+    send_message,
+    get_messages,
+)
+from app.models.chat import CreateChat, SendMessage
+
+@pytest.mark.asyncio
+async def test_create_chat_same_user():
+    payload = CreateChat(isu_1=123456, isu_2=123456)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await create_chat(payload)
+    
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "chat cannot be created for the same user"
+
+@pytest.mark.asyncio
+async def test_create_chat_success():
+    payload = CreateChat(isu_1=123456, isu_2=789012)
+
+    with patch('app.api.chats.db_instance.create_chat', new_callable=AsyncMock) as mock_create_chat:
+        result = await create_chat(payload)
+        assert "chat_id" in result
+        assert isinstance(result["chat_id"], str)
+
+        mock_create_chat.assert_awaited_once_with(
+            chat_id=result["chat_id"],
+            isu_1=payload.isu_1,
+            isu_2=payload.isu_2
+        )
+
+@pytest.mark.asyncio
+async def test_get_chats_for_user_not_found():
+    isu = 123456
+
+    with patch('app.api.chats.db_instance.get_chats_by_user', new_callable=AsyncMock) as mock_get_chats_by_user:
+        mock_get_chats_by_user.return_value = []
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_chats_for_user(isu)
+        
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "chats not found for this user"
+
+        mock_get_chats_by_user.assert_awaited_once_with(isu)
+
+@pytest.mark.asyncio
+async def test_get_chats_for_user_success():
+    isu = 123456
+    chats = [{"chat_id": "meowmeowkillmenow1111"}, {"chat_id": "r4nd0m"}]
+
+    with patch('app.api.chats.db_instance.get_chats_by_user', new_callable=AsyncMock) as mock_get_chats_by_user:
+        mock_get_chats_by_user.return_value = chats
+
+        result = await get_chats_for_user(isu)
+        assert result == {"chats": chats}
+
+        mock_get_chats_by_user.assert_awaited_once_with(isu)
+
+@pytest.mark.asyncio
+async def test_send_message_success():
+    payload = SendMessage(
+        chat_id="aboba123",
+        sender_id=123456,
+        receiver_id=789012,
+        text="meow"
+    )
+
+    with patch('app.api.chats.db_instance.create_message', new_callable=AsyncMock) as mock_create_message:
+        mock_create_message.return_value = "message_id_123"
+
+        result = await send_message(payload)
+        assert result == {"message_id": "message_id_123"}
+
+        mock_create_message.assert_awaited_once_with(
+            chat_id=payload.chat_id,
+            sender_id=payload.sender_id,
+            receiver_id=payload.receiver_id,
+            text=payload.text
+        )
+
+@pytest.mark.asyncio
+async def test_get_messages_not_found():
+    chat_id = "abobus123"
+    limit = 5
+    offset = 0
+
+    with patch('app.api.chats.db_instance.get_messages', new_callable=AsyncMock) as mock_get_messages:
+        mock_get_messages.return_value = []
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_messages(chat_id, limit, offset)
+        
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "messages not found"
+
+        mock_get_messages.assert_awaited_once_with(chat_id=chat_id, limit=limit, offset=offset)
+
+@pytest.mark.asyncio
+async def test_get_messages_success():
+    chat_id = "abobus131"
+    limit = 5
+    offset = 0
+    messages = [
+        {
+            "message_id": "msg1",
+            "sender_id": 123456,
+            "receiver_id": 789012,
+            "text": "meow",
+            "timestamp": "2023-01-01T00:00:00Z"
+        }
+    ]
+
+    with patch('app.api.chats.db_instance.get_messages', new_callable=AsyncMock) as mock_get_messages:
+        mock_get_messages.return_value = messages
+
+        result = await get_messages(chat_id, limit, offset)
+        assert result == {"messages": messages}
+
+        mock_get_messages.assert_awaited_once_with(chat_id=chat_id, limit=limit, offset=offset)

--- a/tests/unit/chats_test.py
+++ b/tests/unit/chats_test.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi import HTTPException
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from app.api.chats import (
     create_chat,
     get_chats_for_user,


### PR DESCRIPTION
### Описание изменений
Добавлены простейшие чаты

Эндпоинты позволяют:
- `create_chat` - создание чата на основе пейлода `CreateChat`, post запрос. Эндпоинт - `/chats/create_chat`.
Принимает (I) и возвращает (O):
  - (I) `CreateChat` - json пейлод, про пейлоды в конце.
  - (O) `chat_id` - id созданного чата.
- `get_chats_for_user` - получить список id чатов для пользователя на основе `isu`, get запрос. Эндпоинт - `/chats/user_chats/{isu}`.
Принимает (I) и возвращает (O):
  - (I) `isu` - isu пользователя, int.
  - (O) `chats` - список id чатов, `json(?)`.
- `send_message` - отправить сообщение от одного пользователя к другому, post запрос. Эндпоинт - `/chats/send_message`.
Принимает (I) и возвращает (O):
  - (I) `SendMessage` - пейлод с информацией о сообщении, про пейлоды в конце, json.
  - (O) `message_id` - id отправленного сообщения, int.
- `get_messages` - получить список сообщения для чата по его `chat_id`, get запрос. Эндпоинт - `/chats/get_messages/{chat_id}`.
Принимает (I) и возвращает (O):
  - (I) `chat_id` - id чата, str.
  - (I) `limit` - лимит сообщений, int, стандартно 5, > 0.
  - (I) `offset` - отступ по сообщениям, int, стандартно 0, >= 0.
  - (O) `messages` - список сообщений. Каждое сообщение содержит `message_id`, `sender_id`, `reciever_id`, `text`, `timestamp`.

Пейлоды:
- `CreateChat`. Содержит `isu_1` (int), `isu_2` (int).
- `SendMessage`. Содержит `chat_id` (str), `sender_id` (int), `reciever_id` (int), `text` (str)
  

### Зачем нужны эти изменения?

Изменения нужны для работы с чатами

### Чек-лист
- [x] Я проверил(-а) изменения в локальной среде
- [x] Я добавил(а) тесты, чтобы покрыть свои изменения
- [x] Все существующие и новые тесты проходят успешно
